### PR TITLE
fixed incorrect logging format and increased DEFAULT_REORG_MN_CHECK f…

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -453,13 +453,13 @@ public:
         fTestnetToBeDeprecatedFieldRPC = true;
 
 
-	checkpointData = (CCheckpointData) {
-		boost::assign::map_list_of
-		( 0, consensus.hashGenesisBlock),
-		genesis.nTime,
-		0,
-		0
-	};
+        checkpointData = (CCheckpointData) {
+            boost::assign::map_list_of
+            ( 0, consensus.hashGenesisBlock),
+            genesis.nTime,
+            0,
+            0
+        };
 
         // Hardcoded fallback value for the Sprout shielded value pool balance
         // for nodes that have not reindexed since the introduction of monitoring
@@ -469,7 +469,7 @@ public:
         fZIP209Enabled = true;
         hashSproutValuePoolCheckpointBlock = uint256S("000a95d08ba5dcbabe881fc6471d11807bcca7df5f1795c99f3ec4580db4279b"); // no idea
 
-	nStartMasternodePayments = 1520121600; //2018-03-04
+	    nStartMasternodePayments = 1520121600; //2018-03-04
         masternodeProtectionBlock = 17500;
         masternodeCollateral = 10;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);;
 map<uint256, int64_t> mapRejectedBlocks  GUARDED_BY(cs_main);;
 void EraseOrphansFor(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-static const unsigned int DEFAULT_REORG_MN_CHECK = 10;
+static const unsigned int DEFAULT_REORG_MN_CHECK = 30;
 
 /**
  * Returns true if there are nRequired or more blocks of minVersion or above
@@ -3849,14 +3849,10 @@ static CBlockIndex* FindMostWorkChain() {
                 const CBlockIndex *pindexTestCheck = FindBlockAtHeight(heightCheck, (const CBlockIndex*)pindexTest);
                 if(pindexOldTipCheck->phashBlock != pindexTestCheck->phashBlock)
                 {
-                    auto msg = strprintf(
-                    "Invalid block hash"
-                      "\n\n") +
-                    _("Block details") + ":\n" +
-                    "- " + strprintf(_("Current tip: %s, height %d"),
-                        pindexOldTipCheck->phashBlock->GetHex(), pindexOldTipCheck->nHeight) + "\n" +
-                    "- " + strprintf(_("New tip:     %s, height %d"),
-                        pindexTestCheck->phashBlock->GetHex(), pindexTestCheck->nHeight) + "\n";
+                    auto msg = "Invalid block hash\n\n" + _("Block details") + ":\n" +
+                    "- " + strprintf(_("Current tip: %s, height %d"), pindexOldTipCheck->phashBlock->GetHex(), pindexOldTipCheck->nHeight) + "\n" +
+                    "- " + strprintf(_("New tip:     %s, height %d"), pindexTestCheck->phashBlock->GetHex(), pindexTestCheck->nHeight) + "\n";
+
                     LogPrintf("*** %s\n", msg);
                     fInvalidChain = true;
                 }


### PR DESCRIPTION
- MN protection might be the reason EQ pool forks the chain from time to time when it has 80-100% of the mining power, so I think increasing the REORG allowed to 30 might help. 
- Fixed wrong logging format